### PR TITLE
Refactor JSON serialization to use `JsonSerializerContext`

### DIFF
--- a/src/OpenCli/Internal/OpenCliJsonContext.cs
+++ b/src/OpenCli/Internal/OpenCliJsonContext.cs
@@ -1,0 +1,18 @@
+#if OPENCLI
+#pragma warning restore
+#else
+#pragma warning disable
+#endif
+
+using System.Text.Json.Serialization;
+
+namespace OpenCli.Internal;
+
+[JsonSerializable(typeof(JsonModel.DocumentJson))]
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    AllowTrailingCommas = true)]
+internal partial class OpenCliJsonContext : JsonSerializerContext
+{
+}

--- a/src/OpenCli/Internal/OpenCliParser.cs
+++ b/src/OpenCli/Internal/OpenCliParser.cs
@@ -498,16 +498,9 @@ internal static class OpenCliParser
     {
         try
         {
-#pragma warning disable IL2026
-#pragma warning disable IL3050
-            // TODO: Remove pragma
-            var jsonDocument = JsonSerializer.Deserialize<JsonModel.DocumentJson>(
-                json, new JsonSerializerOptions
-                {
-                    AllowTrailingCommas = true,
-                });
-#pragma warning restore IL3050
-#pragma warning restore IL2026
+            var jsonDocument = JsonSerializer.Deserialize(
+                json,
+                OpenCliJsonContext.Default.DocumentJson);
             return jsonDocument;
         }
         catch

--- a/src/OpenCli/Internal/OpenCliWriter.cs
+++ b/src/OpenCli/Internal/OpenCliWriter.cs
@@ -5,18 +5,11 @@
 #endif
 
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace OpenCli.Internal;
 
 internal static class OpenCliWriter
 {
-    private static readonly JsonSerializerOptions _options = new JsonSerializerOptions
-    {
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
     public static string Write(OpenCliDocument document)
     {
         if (document == null)
@@ -26,7 +19,7 @@ internal static class OpenCliWriter
 
         return JsonSerializer.Serialize(
             OpenCliMapper.Map(document),
-            _options);
+            OpenCliJsonContext.Default.DocumentJson);
     }
 
     public static void Write(Stream stream, OpenCliDocument document)
@@ -39,6 +32,6 @@ internal static class OpenCliWriter
         JsonSerializer.Serialize(
             stream,
             OpenCliMapper.Map(document),
-            _options);
+            OpenCliJsonContext.Default.DocumentJson);
     }
 }


### PR DESCRIPTION
If Spectre.Console.Cli is going to have AOT support, this needs to have AOT support too. I've never worked with a source only package this way, but I'm struggling to think of a reason this wouldn't work for users and it seems to pack up just fine.

I feel like I might be missing something with `IL2026` and `IL3050` being disabled explicitly though, so no hard feeling if this gets punted :-)